### PR TITLE
Bugfix: Incorrect storage of previous random value

### DIFF
--- a/widget-src/logic.tsx
+++ b/widget-src/logic.tsx
@@ -64,9 +64,9 @@ export function getNewColor() {
   return { r: nR, g: nG, b: nB };
 }
 
+var prevrand = 0;
 export function rand(max: number) {
   var counter = 1;
-  var prevrand = 0;
   var time = new Date().getTime();
   var randValue = (time / counter / (prevrand + 1)) % max;
   counter++;


### PR DESCRIPTION
Moved the `prevrand` variable outside the scope of `rand` function, so that it won't be re-declared and initialised to zero every time the function is invoked.